### PR TITLE
Fixed issue with attachments when no attachments are returned for mail template

### DIFF
--- a/src/Hermes/SendEmailHandler.php
+++ b/src/Hermes/SendEmailHandler.php
@@ -37,7 +37,12 @@ class SendEmailHandler implements HandlerInterface
             return false;
         }
 
-        $attachments = $mailTemplate->attachments_enabled ? $payload['attachments'] : [];
+        $attachments = $payload['attachments'];
+        if (isset($mailTemplate->attachments_enabled) && $mailTemplate->attachments_enabled === false) {
+            // If mailer explicitly doesn't allow attachments, don't include it. If the flag is not set, it's probably
+            // older version of Mailer without the flag. In that case allow the attachments.
+            $attachments = [];
+        }
 
         $this->apiClient->sendEmail(
             $payload['email'],

--- a/src/Hermes/SendEmailHandler.php
+++ b/src/Hermes/SendEmailHandler.php
@@ -37,7 +37,7 @@ class SendEmailHandler implements HandlerInterface
             return false;
         }
 
-        $attachments = $payload['attachments'];
+        $attachments = $payload['attachments'] ?? [];
         if (isset($mailTemplate->attachments_enabled) && $mailTemplate->attachments_enabled === false) {
             // If mailer explicitly doesn't allow attachments, don't include it. If the flag is not set, it's probably
             // older version of Mailer without the flag. In that case allow the attachments.
@@ -49,7 +49,7 @@ class SendEmailHandler implements HandlerInterface
             $payload['mail_template_code'],
             $payload['params'] ?? [],
             $payload['context'] ?? null,
-            $attachments,
+            $attachments ?: [],
             $payload['schedule_at'] ?? null
         );
 


### PR DESCRIPTION
Fixed issue: Argument 5 passed to Crm\RempMailerModule\Models\Api\Client::sendEmail() must be of the type array, null given, called in /var/www/html/vendor/remp/crm-remp-mailer-module/src/Hermes/SendEmailHandler.php on line 53