### PR TITLE
Add correct link into admin main menu

### DIFF
--- a/src/RempMailerModule.php
+++ b/src/RempMailerModule.php
@@ -92,7 +92,7 @@ class RempMailerModule extends CrmModule
 
     public function registerAdminMenuItems(MenuContainerInterface $menuContainer)
     {
-        $mainMenu = new MenuItem($this->translator->translate('remp_mailer.menu.main'), '#', 'fa fa-rocket', 749, false);
+        $mainMenu = new MenuItem($this->translator->translate('remp_mailer.menu.main'), '#remp', 'fa fa-rocket', 749, false);
 
         $menuItem = new MenuItem($this->translator->translate('remp_mailer.menu.mailer'), Core::env('REMP_MAILER_HOST'), 'fa fa-envelope', 2000, false);
         $menuContainer->attachMenuItemToForeignModule('#remp', $mainMenu, $menuItem);


### PR DESCRIPTION
Hi, I've created this PR because I am not able to extend REMP menu without this change.

I am trying to add Beam and Campaigner links into the remp menu using this snippet in my module:
```
    public function registerAdminMenuItems(MenuContainerInterface $menuContainer)
    {
        $mainMenu = new MenuItem($this->translator->translate('remp_mailer.menu.main'), '#remp', 'fa fa-rocket', 749, false);

        $menuItem = new MenuItem('Beam', Core::env('REMP_BEAM_HOST'), 'fa fa-envelope', 2010, false);
        $menuContainer->attachMenuItemToForeignModule('#remp', $mainMenu, $menuItem);
        
        $menuItem = new MenuItem('Campaigner', Core::env('REMP_CAMPAIGNER_HOST'), 'fa fa-envelope', 2020, false);
        $menuContainer->attachMenuItemToForeignModule('#remp', $mainMenu, $menuItem);
    }
```
but it seems to be impossible without provided change.